### PR TITLE
Add Non-Throwing Operation protocol.

### DIFF
--- a/Sources/Common/Core/Domain/Operation.swift
+++ b/Sources/Common/Core/Domain/Operation.swift
@@ -2,6 +2,7 @@
 //  Copyright © 2016 Cleverlance. All rights reserved.
 //
 
+// MARK: Throwing
 public protocol OperationProtocol {
     associatedtype Input
     associatedtype Output
@@ -21,4 +22,28 @@ open class TaggedOperation<Input, Output, Tag>: AbstractClass, OperationProtocol
     public init() {}
 
     open func execute(with input: Input) throws -> Output { virtualMethod }
+}
+
+open func execute(with input: Input) throws -> Output { virtualMethod } }
+
+// MARK: Non-Throwing
+public protocol NonThrowingOperationProtocol {
+    associatedtype Input
+    associatedtype Output
+    
+    func execute(with input: Input) -> Output
+}
+
+extension NonThrowingOperationProtocol where Input == Empty {
+    public func execute() -> Output {
+        return execute(with: Empty())
+    }
+}
+
+public typealias NonThrowingOperation<Input, Output> = TaggedNonThrowingOperation<Input, Output, Void>
+
+open class TaggedNonThrowingOperation<Input, Output, Tag>: AbstractClass, NonThrowingOperationProtocol {
+    public init() {}
+
+    open func execute(with input: Input) -> Output { virtualMethod }
 }


### PR DESCRIPTION
Add Non-Throwing Operation protocol for operations that do not need to throw errors (e.g., generating a UUID operation which always succeeds).